### PR TITLE
Linux kernel driver build fixes for 6.4 up to 6.9

### DIFF
--- a/src/mera/pcie_driver/usd_pcie.c
+++ b/src/mera/pcie_driver/usd_pcie.c
@@ -444,7 +444,11 @@ static int pcie_probe(struct pci_dev *pdev, const struct pci_device_id *ent) {
     goto err_unregister_chrdev;
   }
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 4, 0)
+  epdev->devclass = class_create(pcie_name);
+#else
   epdev->devclass = class_create(THIS_MODULE, pcie_name);
+#endif
   if (IS_ERR(epdev->devclass)) {
     printk(KERN_ERR SAKURA_PREFIX "Failed to create class for cdev. Aborting.\n");
     ret = -ENODEV;

--- a/src/mera/pcie_driver/usd_pcie.c
+++ b/src/mera/pcie_driver/usd_pcie.c
@@ -84,7 +84,11 @@ static int pcie_mmap(struct file *file, struct vm_area_struct *vma) {
     return -EINVAL;
   }
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 3, 0)
+  vm_flags_set(vma, VM_LOCKED);
+#else
   vma->vm_flags |= VM_LOCKED;
+#endif
 
   // Calculate page frame number (PFN).
   vma->vm_pgoff = virt_to_phys(epdev->image[minor].map_addr) >> PAGE_SHIFT;


### PR DESCRIPTION
Update kernel driver code to build successfully on SUSE Linux Micro 6.0 (6.4 based) and openSUSE Tumbleweed (currently at 6.9, rolling release).

Specifically adjust to changes in `class_create()` and `vm_flags` by checking `LINUX_VERSION_CODE`.